### PR TITLE
feat: Add 'documenten.lezen' and 'zaken.lezen' scopes

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,7 @@ python-dateutil
 pytz
 raven
 markdown
+pyyaml==6.0.1
 
 Django~=3.2.0
 django-axes

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -188,8 +188,9 @@ pytz==2022.1
     # via
     #   -r requirements/base.in
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
+    #   -r requirements/base.in
     #   drf-spectacular
     #   gemma-zds-client
     #   oyaml

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -293,7 +293,7 @@ pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -299,7 +299,7 @@ pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -263,7 +263,7 @@ pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/base.txt
     #   drf-spectacular

--- a/src/ztc/api/scopes.py
+++ b/src/ztc/api/scopes.py
@@ -15,6 +15,24 @@ SCOPE_CATALOGI_READ = Scope(
 """,
 )
 
+SCOPE_DOCUMENTEN_READ = Scope(
+    "documenten.lezen",
+    description="""
+**Laat toe om**:
+
+* leesoperaties uit te voeren vanaf de Documenten API. Alle resources zijn beschikbaar.
+""",
+)
+
+SCOPE_ZAKEN_READ = Scope(
+    "zaken.lezen",
+    description="""
+**Laat toe om**:
+
+* leesoperaties uit te voeren vanaf de Zaken API. Alle resources zijn beschikbaar.
+""",
+)
+
 SCOPE_CATALOGI_WRITE = Scope(
     "catalogi.schrijven",
     description="""

--- a/src/ztc/api/tests/test_zaken.py
+++ b/src/ztc/api/tests/test_zaken.py
@@ -35,6 +35,8 @@ from ..scopes import (
     SCOPE_CATALOGI_FORCED_WRITE,
     SCOPE_CATALOGI_READ,
     SCOPE_CATALOGI_WRITE,
+    SCOPE_DOCUMENTEN_READ,
+    SCOPE_ZAKEN_READ,
 )
 from .base import APITestCase
 
@@ -1645,3 +1647,25 @@ class ZaakTypeScopeTests(APITestCase, JWTAuthMixin):
 
         zaaktype.refresh_from_db()
         self.assertEqual(zaaktype.aanleiding, "aangepast")
+
+
+class ZaakTypeExpandDocumentsScopeTests(APITestCase, JWTAuthMixin):
+    heeft_alle_autorisaties = False
+    scopes = [SCOPE_DOCUMENTEN_READ]
+
+    def test_get_list_default_definitief(self):
+        ZaakTypeAPITests.test_get_list_default_definitief(self)
+
+    def test_get_detail(self):
+        ZaakTypeAPITests.test_get_detail(self)
+
+
+class ZaakTypeExpandZaakScopeTests(APITestCase, JWTAuthMixin):
+    heeft_alle_autorisaties = False
+    scopes = [SCOPE_ZAKEN_READ]
+
+    def test_get_list_default_definitief(self):
+        ZaakTypeAPITests.test_get_list_default_definitief(self)
+
+    def test_get_detail(self):
+        ZaakTypeAPITests.test_get_detail(self)

--- a/src/ztc/api/views/zaken.py
+++ b/src/ztc/api/views/zaken.py
@@ -20,6 +20,8 @@ from ..scopes import (
     SCOPE_CATALOGI_FORCED_WRITE,
     SCOPE_CATALOGI_READ,
     SCOPE_CATALOGI_WRITE,
+    SCOPE_DOCUMENTEN_READ,
+    SCOPE_ZAKEN_READ,
 )
 from ..serializers import (
     ZaakTypeCreateSerializer,
@@ -112,8 +114,8 @@ class ZaakTypeViewSet(
     lookup_field = "uuid"
     filterset_class = ZaakTypeFilter
     required_scopes = {
-        "list": SCOPE_CATALOGI_READ,
-        "retrieve": SCOPE_CATALOGI_READ,
+        "list": SCOPE_CATALOGI_READ | SCOPE_DOCUMENTEN_READ | SCOPE_ZAKEN_READ,
+        "retrieve": SCOPE_CATALOGI_READ | SCOPE_DOCUMENTEN_READ | SCOPE_ZAKEN_READ,
         "create": SCOPE_CATALOGI_WRITE,
         "update": SCOPE_CATALOGI_WRITE | SCOPE_CATALOGI_FORCED_WRITE,
         "partial_update": SCOPE_CATALOGI_WRITE | SCOPE_CATALOGI_FORCED_WRITE,


### PR DESCRIPTION
This commit introduces two new scopes, 'documenten.lezen' and 'zaken.lezen', to the catalogi-api. These scopes inherit the same permissions as the existing 'catalogi.lezen' scope. The addition of these scopes is necessary to accommodate the new expand model, which involves requesting information from the catalogi-api through the documenten-api and zaken-api.

Issue #2262